### PR TITLE
First pass changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,11 @@ plugins {
 group = "io.liftbridge"
 version = "0.1.0-alpha0"
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 sourceSets {
     main {
         java {

--- a/src/main/java/io/liftbridge/Client.java
+++ b/src/main/java/io/liftbridge/Client.java
@@ -1,32 +1,40 @@
 package io.liftbridge;
 
 import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
-import io.liftbridge.MessageHandler;
 import io.liftbridge.proto.APIGrpc.APIStub;
 import io.liftbridge.proto.APIGrpc.APIBlockingStub;
 import io.liftbridge.proto.APIGrpc;
 import io.liftbridge.proto.Api;
 import com.google.protobuf.ByteString;
-import java.nio.ByteBuffer;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * {@code Client} is the main API used to communicate with a Liftbridge cluster. Use {@link Builder#build()} to
+ * construct a {@code Client} instance.
+ */
 public class Client {
+
     private APIStub asyncStub;
     private APIBlockingStub blockingStub;
-    private Client(APIStub asyncStub, APIBlockingStub blockingStub) {
-        this.asyncStub = asyncStub;
-        this.blockingStub = blockingStub;
+    private ManagedChannel channel;
+
+    private Client(ManagedChannel channel) {
+        this.channel = channel;
+        this.asyncStub = APIGrpc.newStub(channel);
+        this.blockingStub = APIGrpc.newBlockingStub(channel);
     }
 
     /**
-     * Creates a client connected to the API using the provided gRPC channel.
+     * Closes the client connection by shutting down the gRPC channel and releasing any resources.
      */
-    public static Client connect(ManagedChannel grpcChannel) {
-        return new Client(APIGrpc.newStub(grpcChannel),
-                          APIGrpc.newBlockingStub(grpcChannel));
+    public void close() {
+        channel.shutdown();
     }
-
 
     /**
      * Creates a stream. Will block until response is received.
@@ -36,20 +44,36 @@ public class Client {
     }
 
     /**
+     * Creates a stream. Will block until response is received.
+     */
+    public void createStream(String streamName) {
+        createStream(streamName, new StreamOptions());
+    }
+
+    /**
      * Subscribes to a stream.
      */
-    public void subscribe(String streamName, MessageHandler msgHandler,
-                          SubscriptionOptions opts) {
+    public void subscribe(String streamName, SubscriptionOptions opts, MessageHandler msgHandler) {
         opts = opts.setStreamName(streamName);
         asyncStub.subscribe(opts.asRequest(), new StreamObserver<Api.Message>() {
-                public void onNext(Api.Message message) {
-                    msgHandler.onMessage(io.liftbridge.Message.fromWire(message));
-                }
-                public void onError(Throwable t) {
-                    msgHandler.onError(t);
-                }
-                public void onCompleted() {}
-            });
+            public void onNext(Api.Message message) {
+                msgHandler.onMessage(io.liftbridge.Message.fromWire(message));
+            }
+
+            public void onError(Throwable t) {
+                msgHandler.onError(t);
+            }
+
+            public void onCompleted() {
+            }
+        });
+    }
+
+    /**
+     * Subscribes to a stream.
+     */
+    public void subscribe(String streamName, MessageHandler msgHandler) {
+        subscribe(streamName, new SubscriptionOptions(), msgHandler);
     }
 
     /**
@@ -59,16 +83,68 @@ public class Client {
     public void publish(String subject, byte[] payload,
                         long deadlineDuration, TimeUnit deadlineUnit) {
         Api.Message msg = Api.Message.newBuilder()
-            .setSubject(subject)
-            .setValue(ByteString.copyFrom(payload))
-            .setAckPolicy(Api.AckPolicy.LEADER)
-            .build();
+                .setSubject(subject)
+                .setValue(ByteString.copyFrom(payload))
+                .setAckPolicy(Api.AckPolicy.LEADER)
+                .build();
 
         Api.PublishRequest req = Api.PublishRequest.newBuilder()
-            .setMessage(msg)
-            .build();
+                .setMessage(msg)
+                .build();
 
         blockingStub.withDeadlineAfter(deadlineDuration, deadlineUnit)
-            .publish(req);
+                .publish(req);
     }
+
+    /**
+     * {@code Builder} is used to configure and construct a {@link Client} instance.
+     */
+    public static class Builder {
+
+        private final List<String> addrs = new ArrayList<>();
+
+        private Builder() {
+        }
+
+        /**
+         * Creates a {@link Builder} that will connect to the given broker address.
+         *
+         * @param addr broker address
+         * @return {@code Builder}
+         */
+        public static Builder create(String addr) {
+            Builder builder = new Builder();
+            return builder.withBroker(addr);
+        }
+
+        /**
+         * Adds the given address to the set of broker hosts the client will use when attempting to connect.
+         *
+         * @param addr broker address
+         * @return {@code this} to allow for call chaining
+         */
+        Builder withBroker(String addr) {
+            addrs.add(addr);
+            return this;
+        }
+
+        /**
+         * Creates a configured {@link Client} instance.
+         *
+         * @return {@code Client}
+         */
+        public Client build() {
+            if (addrs.size() == 0) {
+                throw new RuntimeException("no addresses provided");
+            }
+
+            // TODO: Handle multiple addresses.
+            ManagedChannelBuilder channelBuilder = ManagedChannelBuilder.forTarget(addrs.get(0));
+
+            // TODO: Implement TLS.
+            ManagedChannel channel = channelBuilder.usePlaintext().build();
+            return new Client(channel);
+        }
+    }
+
 }

--- a/src/main/java/io/liftbridge/Message.java
+++ b/src/main/java/io/liftbridge/Message.java
@@ -1,6 +1,7 @@
 package io.liftbridge;
 
 import io.liftbridge.proto.Api;
+
 import java.util.HashMap;
 
 public class Message {
@@ -12,7 +13,8 @@ public class Message {
     private String replySubject;
     private HashMap<String, byte[]> headers;
 
-    Message(){}
+    private Message() {
+    }
 
     static Message fromWire(Api.Message wireMsg) {
         Message msg = new Message();
@@ -25,93 +27,101 @@ public class Message {
         return msg;
     }
 
-    Api.Message toWire() {
-        Api.Message.Builder msg = Api.Message.newBuilder();
-        return msg.build();
+    /**
+     * @return the offset
+     */
+    public Long getOffset() {
+        return offset;
     }
 
-	/**
-	 * @return the offset
-	 */
-	public Long getOffset() {
-		return offset;
-	}
-	/**
-	 * @param offset the offset to set
-	 */
-	private void setOffset(Long offset) {
-		this.offset = offset;
-	}
-	/**
-	 * @return the key
-	 */
-	public byte[] getKey() {
-		return key;
-	}
-	/**
-	 * @param key the key to set
-	 */
-	private void setKey(byte[] key) {
-		this.key = key;
-	}
-	/**
-	 * @return the value
-	 */
-	public byte[] getValue() {
-		return value;
-	}
-	/**
-	 * @param value the value to set
-	 */
-	private void setValue(byte[] value) {
-		this.value = value;
-	}
-	/**
-	 * @return the timestampNanos
-	 */
-	public Long getTimestampNanos() {
-		return timestampNanos;
-	}
-	/**
-	 * @param timestampNanos the timestampNanos to set
-	 */
-	private void setTimestampNanos(Long timestampNanos) {
-		this.timestampNanos = timestampNanos;
-	}
-	/**
-	 * @return the subject
-	 */
-	public String getSubject() {
-		return subject;
-	}
-	/**
-	 * @param subject the subject to set
-	 */
-	private void setSubject(String subject) {
-		this.subject = subject;
-	}
-	/**
-	 * @return the replySubject
-	 */
-	public String getReplySubject() {
-		return replySubject;
-	}
-	/**
-	 * @param replySubject the replySubject to set
-	 */
-	private void setReplySubject(String replySubject) {
-		this.replySubject = replySubject;
-	}
-	/**
-	 * @return the headers
-	 */
-	public HashMap<String, byte[]> getHeaders() {
-		return headers;
-	}
-	/**
-	 * @param headers the headers to set
-	 */
-	private void setHeaders(HashMap<String, byte[]> headers) {
-		this.headers = headers;
-	}
+    /**
+     * @param offset the offset to set
+     */
+    private void setOffset(Long offset) {
+        this.offset = offset;
+    }
+
+    /**
+     * @return the key
+     */
+    public byte[] getKey() {
+        return key;
+    }
+
+    /**
+     * @param key the key to set
+     */
+    private void setKey(byte[] key) {
+        this.key = key;
+    }
+
+    /**
+     * @return the value
+     */
+    public byte[] getValue() {
+        return value;
+    }
+
+    /**
+     * @param value the value to set
+     */
+    private void setValue(byte[] value) {
+        this.value = value;
+    }
+
+    /**
+     * @return the timestampNanos
+     */
+    public Long getTimestampNanos() {
+        return timestampNanos;
+    }
+
+    /**
+     * @param timestampNanos the timestampNanos to set
+     */
+    private void setTimestampNanos(Long timestampNanos) {
+        this.timestampNanos = timestampNanos;
+    }
+
+    /**
+     * @return the subject
+     */
+    public String getSubject() {
+        return subject;
+    }
+
+    /**
+     * @param subject the subject to set
+     */
+    private void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    /**
+     * @return the replySubject
+     */
+    public String getReplySubject() {
+        return replySubject;
+    }
+
+    /**
+     * @param replySubject the replySubject to set
+     */
+    private void setReplySubject(String replySubject) {
+        this.replySubject = replySubject;
+    }
+
+    /**
+     * @return the headers
+     */
+    public HashMap<String, byte[]> getHeaders() {
+        return headers;
+    }
+
+    /**
+     * @param headers the headers to set
+     */
+    private void setHeaders(HashMap<String, byte[]> headers) {
+        this.headers = headers;
+    }
 }

--- a/src/main/java/io/liftbridge/StreamOptions.java
+++ b/src/main/java/io/liftbridge/StreamOptions.java
@@ -3,7 +3,8 @@ package io.liftbridge;
 import io.liftbridge.proto.Api.CreateStreamRequest;
 
 public class StreamOptions {
-    private CreateStreamRequest.Builder requestBuilder;
+
+    private final CreateStreamRequest.Builder requestBuilder;
 
     public StreamOptions() {
         requestBuilder = CreateStreamRequest.newBuilder();
@@ -24,12 +25,12 @@ public class StreamOptions {
     /**
      * @return the replicationFactor
      */
-    public Integer getReplicationFactor() {
+    public int getReplicationFactor() {
         return requestBuilder.getReplicationFactor();
     }
 
-    public StreamOptions setReplicationFactor(Integer replicationFactor) {
-        requestBuilder = requestBuilder.setReplicationFactor(replicationFactor);
+    public StreamOptions setReplicationFactor(int replicationFactor) {
+        requestBuilder.setReplicationFactor(replicationFactor);
         return this;
     }
 
@@ -44,30 +45,30 @@ public class StreamOptions {
      * @param group the group to set
      */
     public StreamOptions setGroup(String group) {
-        requestBuilder = requestBuilder.setGroup(group);
+        requestBuilder.setGroup(group);
         return this;
     }
 
     /**
      * @return the partitions
      */
-    public Integer getPartitions() {
+    public int getPartitions() {
         return requestBuilder.getPartitions();
     }
 
     /**
      * @param partitions the partitions to set
      */
-    public StreamOptions setPartitions(Integer partitions) {
-        requestBuilder = requestBuilder.setPartitions(partitions);
+    public StreamOptions setPartitions(int partitions) {
+        requestBuilder.setPartitions(partitions);
         return this;
     }
 
-    CreateStreamRequest asRequest(String stream_name){
-        CreateStreamRequest.Builder req_builder = requestBuilder.setName(stream_name);
-        if(req_builder.getSubject() == null || req_builder.getSubject() == "") {
-            return req_builder.setSubject(stream_name).build();
+    CreateStreamRequest asRequest(String streamName) {
+        CreateStreamRequest.Builder reqBuilder = requestBuilder.setName(streamName);
+        if (reqBuilder.getSubject() == null || reqBuilder.getSubject().isEmpty()) {
+            return reqBuilder.setSubject(streamName).build();
         }
-        return req_builder.build();
+        return reqBuilder.build();
     }
 }

--- a/src/main/java/io/liftbridge/SubscriptionOptions.java
+++ b/src/main/java/io/liftbridge/SubscriptionOptions.java
@@ -4,7 +4,8 @@ import io.liftbridge.proto.Api.SubscribeRequest;
 import io.liftbridge.proto.Api;
 
 public class SubscriptionOptions {
-    private SubscribeRequest.Builder requestBuilder;
+
+    private final SubscribeRequest.Builder requestBuilder;
     private StartPosition startPosition;
     private MessageHandler messageHandler;
 
@@ -17,7 +18,7 @@ public class SubscriptionOptions {
      * Specifies the stream partition to consume. Defaults to 0.
      */
     public SubscriptionOptions setPartition(int partition) {
-        requestBuilder = requestBuilder.setPartition(partition);
+        requestBuilder.setPartition(partition);
         return this;
     }
 
@@ -29,7 +30,7 @@ public class SubscriptionOptions {
         return messageHandler;
     }
 
-    String getStreamName() {
+    public String getStreamName() {
         return requestBuilder.getStream();
     }
 
@@ -53,7 +54,7 @@ public class SubscriptionOptions {
     }
 
     public SubscriptionOptions setStartPosition(StartPosition position) {
-        requestBuilder = position.setRequestBuilderParameters(requestBuilder);
+        position.setRequestBuilderParameters(requestBuilder);
         this.startPosition = position;
         return this;
     }
@@ -62,12 +63,14 @@ public class SubscriptionOptions {
         return requestBuilder.build();
     }
 
-    public abstract static class StartPosition {
+    abstract static class StartPosition {
         abstract SubscribeRequest.Builder setRequestBuilderParameters(SubscribeRequest.Builder builder);
     }
 
     public static class StartAtNewOnly extends StartPosition {
-        StartAtNewOnly() {}
+        StartAtNewOnly() {
+        }
+
         SubscribeRequest.Builder setRequestBuilderParameters(SubscribeRequest.Builder builder) {
             return builder.setStartPosition(Api.StartPosition.NEW_ONLY);
         }
@@ -106,7 +109,7 @@ public class SubscriptionOptions {
 
         SubscribeRequest.Builder setRequestBuilderParameters(SubscribeRequest.Builder builder) {
             return builder.setStartPosition(Api.StartPosition.TIMESTAMP)
-                .setStartTimestamp(this.timestampNanoSeconds);
+                    .setStartTimestamp(this.timestampNanoSeconds);
         }
     }
 }

--- a/src/test/java/io/liftbridge/BaseClientTest.java
+++ b/src/test/java/io/liftbridge/BaseClientTest.java
@@ -1,34 +1,19 @@
 package io.liftbridge;
 
-import org.junit.BeforeClass;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.After;
 import org.junit.Ignore;
-import io.grpc.ManagedChannelBuilder;
-import io.grpc.ManagedChannel;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 
 @Ignore
-public class BaseClientTest{
+public class BaseClientTest {
+
     private static final String SERVER_ADDRESS = "localhost";
     private static final Integer SERVER_PORT = 9292;
 
-    private static ManagedChannel grpcConnect() {
-        ManagedChannelBuilder builder = ManagedChannelBuilder.forAddress(SERVER_ADDRESS, SERVER_PORT);
-        return builder.usePlaintext().build();
-    }
-
-    @BeforeClass
-    public static void setupGrpcChannel() {
-        grpcChannel = grpcConnect();
-    }
-
-    @AfterClass
-    public static void cleanupGrpcChannel() {
-        grpcChannel.shutdown();
-    }
+    String streamName;
+    Client client;
 
     @Before
     public void setupStreamName() {
@@ -37,15 +22,12 @@ public class BaseClientTest{
 
     @Before
     public void setupClient() {
-        this.client = Client.connect(grpcChannel);
+        this.client = Client.Builder.create(SERVER_ADDRESS + ":" + SERVER_PORT).build();
     }
 
     @After
     public void tearDownClient() {
+        this.client.close();
         this.client = null;
     }
-
-    static ManagedChannel grpcChannel;
-    String streamName;
-    Client client;
 }

--- a/src/test/java/io/liftbridge/ClientCreateStreamTest.java
+++ b/src/test/java/io/liftbridge/ClientCreateStreamTest.java
@@ -1,7 +1,6 @@
 package io.liftbridge;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 public class ClientCreateStreamTest extends BaseClientTest {
     // TODO write assertions when a "fetch metadata" method is available

--- a/src/test/java/io/liftbridge/ClientSubscribeTest.java
+++ b/src/test/java/io/liftbridge/ClientSubscribeTest.java
@@ -1,10 +1,12 @@
 package io.liftbridge;
+
 import org.junit.Before;
-import org.junit.After;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 import static org.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.*;
+
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicLong;
 import java.nio.ByteBuffer;
@@ -15,39 +17,45 @@ import java.util.Collections;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 
 public class ClientSubscribeTest extends BaseClientTest {
-    @Before
-    public void setupStreams() {
-        populatedStreamName = randomAlphabetic(10);
-        client.createStream(streamName, new StreamOptions());
-        client.createStream(populatedStreamName, new StreamOptions());
-
-        for(Integer i = 0; i < 10; ++i) {
-            byte[] payload = ByteBuffer.allocate(4).putInt(i).array();
-            client.publish(this.populatedStreamName,
-                           payload,
-                           10, MILLISECONDS);
-        }
-    }
 
     private String populatedStreamName;
 
-    @Test
-    public void testSubscribeDefaultOptions() {
-        client.subscribe(streamName, new MessageHandler(){
-                public void onMessage(io.liftbridge.Message msg){}
-                public void onError(Throwable t){}
-            }, new SubscriptionOptions());
+    @Before
+    public void setupStreams() {
+        populatedStreamName = randomAlphabetic(10);
+        client.createStream(streamName);
+        client.createStream(populatedStreamName);
+
+        for (int i = 0; i < 10; ++i) {
+            byte[] payload = ByteBuffer.allocate(4).putInt(i).array();
+            client.publish(this.populatedStreamName,
+                    payload,
+                    10, MILLISECONDS);
+        }
     }
 
     @Test
-    public void testSubscribeNonExistentStream()  {
-        final AtomicReference<Throwable> streamErr = new AtomicReference<Throwable>(null);
-        client.subscribe(randomAlphabetic(15), new MessageHandler(){
-                public void onMessage(io.liftbridge.Message msg){}
-                public void onError(Throwable t){
-                    streamErr.set(t);
-                }
-            }, new SubscriptionOptions());
+    public void testSubscribeDefaultOptions() {
+        client.subscribe(streamName, new MessageHandler() {
+            public void onMessage(io.liftbridge.Message msg) {
+            }
+
+            public void onError(Throwable t) {
+            }
+        });
+    }
+
+    @Test
+    public void testSubscribeNonExistentStream() {
+        final AtomicReference<Throwable> streamErr = new AtomicReference<>(null);
+        client.subscribe(randomAlphabetic(15), new MessageHandler() {
+            public void onMessage(io.liftbridge.Message msg) {
+            }
+
+            public void onError(Throwable t) {
+                streamErr.set(t);
+            }
+        });
         await().atMost(1, SECONDS).until(() -> streamErr.get() != null);
         assertTrue(streamErr.get() instanceof RuntimeException);
         assertTrue(streamErr.get().getMessage().contains("NOT_FOUND"));
@@ -56,41 +64,45 @@ public class ClientSubscribeTest extends BaseClientTest {
     @Test
     public void testSubscribeFromBeginning() {
         SubscriptionOptions opts = new SubscriptionOptions()
-            .setStartPosition(new SubscriptionOptions.StartAtEarliestReceived());
-        final List<Integer> streamValues = new ArrayList<Integer>();
+                .setStartPosition(new SubscriptionOptions.StartAtEarliestReceived());
+        final List<Integer> streamValues = new ArrayList<>();
 
-        client.subscribe(populatedStreamName, new MessageHandler(){
-                public void onMessage(io.liftbridge.Message msg){
-                    if(msg.getValue().length > 0){
-                        streamValues.add(ByteBuffer.wrap(msg.getValue()).getInt());
-                    }
+        client.subscribe(populatedStreamName, opts, new MessageHandler() {
+            public void onMessage(io.liftbridge.Message msg) {
+                if (msg.getValue().length > 0) {
+                    streamValues.add(ByteBuffer.wrap(msg.getValue()).getInt());
                 }
-                public void onError(Throwable t){}
-            }, opts);
+            }
+
+            public void onError(Throwable t) {
+            }
+        });
 
 
         await().atMost(5, SECONDS).until(() -> streamValues.size() >= 10);
         Collections.sort(streamValues);
         Integer[] vals = new Integer[10];
         assertArrayEquals("All messages were received",
-                          new Integer[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-                          streamValues.toArray(vals));
+                new Integer[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+                streamValues.toArray(vals));
     }
 
     @Test
     public void testSubscribeFromLatestReceived() {
         SubscriptionOptions opts = new SubscriptionOptions()
-            .setStartPosition(new SubscriptionOptions.StartAtLatestReceived());
+                .setStartPosition(new SubscriptionOptions.StartAtLatestReceived());
         final AtomicLong lastOffset = new AtomicLong(-1);
 
-        client.subscribe(populatedStreamName, new MessageHandler(){
-                public void onMessage(io.liftbridge.Message msg){
-                    if(msg.getValue().length > 0) {
-                        lastOffset.set(msg.getOffset());
-                    }
+        client.subscribe(populatedStreamName, opts, new MessageHandler() {
+            public void onMessage(io.liftbridge.Message msg) {
+                if (msg.getValue().length > 0) {
+                    lastOffset.set(msg.getOffset());
                 }
-                public void onError(Throwable t){}
-            }, opts);
+            }
+
+            public void onError(Throwable t) {
+            }
+        });
 
 
         await().atMost(5, SECONDS).until(() -> lastOffset.get() >= 0);
@@ -100,50 +112,54 @@ public class ClientSubscribeTest extends BaseClientTest {
     @Test
     public void testSubscribeFromNewOnly() {
         SubscriptionOptions opts = new SubscriptionOptions();
-        final List<Integer> streamValues = new ArrayList<Integer>();
+        final List<Integer> streamValues = new ArrayList<>();
 
-        client.subscribe(populatedStreamName, new MessageHandler(){
-                public void onMessage(io.liftbridge.Message msg){
-                    if(msg.getValue().length > 0) {
-                        streamValues.add(ByteBuffer.wrap(msg.getValue()).getInt());
-                    }
+        client.subscribe(populatedStreamName, opts, new MessageHandler() {
+            public void onMessage(io.liftbridge.Message msg) {
+                if (msg.getValue().length > 0) {
+                    streamValues.add(ByteBuffer.wrap(msg.getValue()).getInt());
                 }
-                public void onError(Throwable t){}
-            }, opts);
+            }
 
-        for(Integer i = 0; i < 10; ++i) {
+            public void onError(Throwable t) {
+            }
+        });
+
+        for (int i = 0; i < 10; ++i) {
             byte[] payload = ByteBuffer.allocate(20).putInt(i + 10).array();
             client.publish(this.populatedStreamName,
-                           payload, 10, MILLISECONDS);
+                    payload, 10, MILLISECONDS);
         }
         await().atMost(5, SECONDS).until(() -> streamValues.size() >= 10);
         Collections.sort(streamValues);
         Integer[] vals = new Integer[10];
         assertArrayEquals("All messages were received",
-                          new Integer[]{10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
-                          streamValues.toArray(vals));
+                new Integer[]{10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
+                streamValues.toArray(vals));
     }
 
     @Test
     public void testSubscribeFromOffset() {
         SubscriptionOptions opts = new SubscriptionOptions()
-            .setStartPosition(new SubscriptionOptions.StartAtOffset(5L));
-        final List<Long> offsets = new ArrayList<Long>();
+                .setStartPosition(new SubscriptionOptions.StartAtOffset(5L));
+        final List<Long> offsets = new ArrayList<>();
 
-        client.subscribe(populatedStreamName, new MessageHandler(){
-                public void onMessage(io.liftbridge.Message msg){
-                    if(msg.getValue().length > 0) {
-                        offsets.add(msg.getOffset());
-                    }
+        client.subscribe(populatedStreamName, opts, new MessageHandler() {
+            public void onMessage(io.liftbridge.Message msg) {
+                if (msg.getValue().length > 0) {
+                    offsets.add(msg.getOffset());
                 }
-                public void onError(Throwable t){}
-            }, opts);
+            }
+
+            public void onError(Throwable t) {
+            }
+        });
 
         await().atMost(5, SECONDS).until(() -> offsets.size() >= 5);
         Collections.sort(offsets);
         Long[] vals = new Long[5];
         assertArrayEquals("All offset, starting with 5, were received",
-                          new Long[]{5L, 6L, 7L, 8L, 9L},
-                          offsets.toArray(vals));
+                new Long[]{5L, 6L, 7L, 8L, 9L},
+                offsets.toArray(vals));
     }
 }


### PR DESCRIPTION
Proposed changes after first pass through the code. Mostly minor syntax
tweaks and API changes. Only major change is introducing a Builder class
for creating Client instances. This will become more useful once the
rest of the client options are implemented along with connection
retries, pooling, etc.

I've been thinking about what the right API ergonomics are for "options", e.g. `StreamOptions` and `SubscriptionOptions`. In the Go client, we use the [functional options pattern](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis). In Java, the closest equivalent is probably the builder pattern, but that feels too "heavy" in a lot of cases, such as in the case of publishing. I thought about method overloading, but that quickly gets out of hand with all the different combinations of option parameters. It seems just having the _*Options_ classes might be the best solution? I think using a Builder in the case of constructing a `Client` makes sense though.

@caioaao 